### PR TITLE
Added daemon-reload command to README

### DIFF
--- a/README
+++ b/README
@@ -22,7 +22,7 @@ Run 'update-bunsen-pepperflash --help' to see options.
 A systemd timer will run the upgrade check every day.
 To change this behaviour, copy /lib/systemd/system/bunsen-pepperflash.timer to
 /etc/systemd/system/bunsen-pepperflash.timer, edit the latter file, and
-run 'systemctl reenable bunsen-pepperflash.timer'.
+run 'systemctl daemon-reload && systemctl reenable bunsen-pepperflash.timer'.
 
 If the recommended package bunsen-utilities is also installed,
 popup notifications of plugin upgrades or script errors will be displayed.


### PR DESCRIPTION
After modifying unit files, the `daemon-reload` command is needed to parse the changed file.