### PR TITLE
Making bunsen-pepperflash more universal

### DIFF
--- a/update-bunsen-pepperflash
+++ b/update-bunsen-pepperflash
@@ -110,10 +110,6 @@ check_root() {
     [[ $( id -u ) -eq 0 ]] || error_exit "$opt: must be root to use this option"
 }
 
-version(){
-    echo "$@" | gawk -F. '{printf("%03d%03d%03d%03d\n", $1,$2,$3,$4); }'
-}
-
 check_versions(){
     echo 'Checking Flash version available from Adobe...'
     newver=$($version_checker) || error_exit "$version_checker returned an error."
@@ -130,7 +126,7 @@ check_versions(){
         return 0
     fi
 
-    if [ "$(version "$newver")" -gt "$(version "$instver")" ]
+    if [[ "$newver" > "$instver" ]]
     then
         [[ ${quiet-} = true ]] || echo "The upstream version is newer."
         return 0

--- a/update-bunsen-pepperflash
+++ b/update-bunsen-pepperflash
@@ -82,7 +82,7 @@ error_exit() {
 [[ -x "$version_checker" ]] || error_exit "Cannot find necessary script: $version_checker"
 [[ $(dpkg-query --show --showformat='${db:Status-Abbrev;2}' pepperflashplugin-nonfree 2>/dev/null) = ii ]] && error_exit 'pepperflashplugin-nonfree must be uninstalled before using this script.'
 
-case "$(uname -a)" in
+case "$(uname -m)" in
 i*86)
     arch='i386'
     ;;

--- a/update-bunsen-pepperflash
+++ b/update-bunsen-pepperflash
@@ -82,11 +82,11 @@ error_exit() {
 [[ -x "$version_checker" ]] || error_exit "Cannot find necessary script: $version_checker"
 [[ $(dpkg-query --show --showformat='${db:Status-Abbrev;2}' pepperflashplugin-nonfree 2>/dev/null) = ii ]] && error_exit 'pepperflashplugin-nonfree must be uninstalled before using this script.'
 
-case "$(dpkg --print-architecture)" in
-i386)
+case "$(uname -a)" in
+i*86)
     arch='i386'
     ;;
-amd64)
+x86_64)
     arch='x86_64'
     ;;
 *)
@@ -110,6 +110,10 @@ check_root() {
     [[ $( id -u ) -eq 0 ]] || error_exit "$opt: must be root to use this option"
 }
 
+version(){
+    echo "$@" | gawk -F. '{printf("%03d%03d%03d%03d\n", $1,$2,$3,$4); }'
+}
+
 check_versions(){
     echo 'Checking Flash version available from Adobe...'
     newver=$($version_checker) || error_exit "$version_checker returned an error."
@@ -126,7 +130,7 @@ check_versions(){
         return 0
     fi
 
-    if dpkg --compare-versions "$newver" gt "$instver"
+    if [ "$(version "$newver")" -gt "$(version "$instver")" ]
     then
         [[ ${quiet-} = true ]] || echo "The upstream version is newer."
         return 0


### PR DESCRIPTION
I've just made these changes to a local version of the `update-bunsen-pepperflash` script to remove two `dpkg` commands and replace them with more universal alternatives (to get it working in my Arch box) — would this be worth merging?